### PR TITLE
add Page Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ArabicCompetitiveProgramming
 ============================
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fmostafa-saad%2FArabicCompetitiveProgramming&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)
 
 The repository will contain the description files attached to the video series in my algorithms channel.


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. If there is the website built from this repo, it can be simply added there too.

Even if you already have the YouTube channel, I think this one is still needed.

![Screenshot (1656)](https://user-images.githubusercontent.com/47092464/98453085-46194300-2190-11eb-8320-0043c1bfd1a4.png)
